### PR TITLE
Add gaming & steam presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,23 @@ without having to install packages globally.
    ```bash
    nix-shell
    ```
-3. Run phoronix test suite benchmarks. A convenience script is provided to
-   run a small set of common tests:
+3. Run phoronix test suite benchmarks using the convenience script. By default
+   it runs a set of common system tests:
    ```bash
    ./run-benchmarks.sh
    ```
-   This will execute benchmarks such as `openssl`, `nginx`, `python`,
-   `phpbench`, and `compress-7zip` using the `batch-benchmark` command.
+   For gaming focused benchmarks use the `gaming` preset:
+   ```bash
+   ./run-benchmarks.sh gaming
+   ```
+   To run all Steam game benchmarks supported by the test suite use the
+   `steam` preset:
+   ```bash
+   ./run-benchmarks.sh steam
+   ```
+   The default preset executes benchmarks such as `openssl`, `nginx`,
+   `python`, `phpbench`, and `compress-7zip` using the `batch-benchmark`
+   command.
 
 Feel free to adjust the `TESTS` array in `run-benchmarks.sh` to include
 other benchmarks available in the phoronix test suite.

--- a/run-benchmarks.sh
+++ b/run-benchmarks.sh
@@ -1,13 +1,52 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Predefined set of common phoronix test suite benchmarks
-TESTS=(
-  pts/openssl
-  pts/nginx
-  pts/python
-  pts/phpbench
-  pts/compress-7zip
-)
+# Run a set of benchmarks from the phoronix-test-suite.
+# Usage: ./run-benchmarks.sh [preset]
+#
+# Presets:
+#   default - Common system benchmarks (default)
+#   gaming  - Popular GPU/graphics benchmarks
+#   steam   - All Steam game benchmarks supported by PTS
+
+preset="${1:-default}"
+
+case "$preset" in
+  default)
+    TESTS=(
+      pts/openssl
+      pts/nginx
+      pts/python
+      pts/phpbench
+      pts/compress-7zip
+    )
+    ;;
+  gaming)
+    TESTS=(
+      pts/unigine-tropics
+      pts/unigine-sanctuary
+      pts/unigine-heaven
+      pts/unigine-valley
+      pts/unigine-superposition
+      pts/3dmark
+      pts/furmark
+      pts/gfxbench
+      pts/gputest
+      pts/urbanterror
+    )
+    ;;
+  steam)
+    mapfile -t TESTS < <(phoronix-test-suite list-tests | awk '/Steam/ {print $1}')
+    if [ ${#TESTS[@]} -eq 0 ]; then
+      echo "No Steam game benchmarks found in phoronix-test-suite." >&2
+      exit 1
+    fi
+    ;;
+  *)
+    echo "Unknown preset: $preset" >&2
+    echo "Usage: $0 [default|gaming|steam]" >&2
+    exit 1
+    ;;
+esac
 
 phoronix-test-suite batch-benchmark "${TESTS[@]}"


### PR DESCRIPTION
## Summary
- add `gaming` and `steam` presets to `run-benchmarks.sh`
- document new presets in README

## Testing
- `bash -n run-benchmarks.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a15e183f0832c8fab04b55e6bfb34