### PR TITLE
Add minimal Python benchmark runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .direnv
+cache
+results

--- a/README.md
+++ b/README.md
@@ -54,3 +54,16 @@ The environment includes the following packages:
 
 These dependencies cover a variety of test scenarios so the suite should
 run out-of-the-box on most systems.
+
+## Minimal Benchmark Runner
+A simple Python script `pts_nix.py` reimplements basic functionality of the Phoronix Test Suite. It supports running `phpbench`, the `7zip` compression test and an `openssl` speed benchmark. Results are written to the `results/` directory in JSON format.
+
+Run all benchmarks:
+```bash
+python pts_nix.py
+```
+Specify individual benchmarks:
+```bash
+python pts_nix.py phpbench 7zip
+```
+

--- a/pts_nix.py
+++ b/pts_nix.py
@@ -1,0 +1,124 @@
+# Minimal Phoronix Test Suite reimplementation for NixOS
+# Supports phpbench, 7zip and openssl benchmarks
+import argparse
+import os
+import re
+import subprocess
+import tarfile
+import shutil
+import urllib.request
+import json
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+CACHE = os.path.join(ROOT, 'cache')
+RESULTS = os.path.join(ROOT, 'results')
+
+os.makedirs(CACHE, exist_ok=True)
+os.makedirs(RESULTS, exist_ok=True)
+
+class Benchmark:
+    name: str
+
+    def download(self, url: str, dest: str):
+        if not os.path.exists(dest):
+            print(f'Downloading {url}')
+            urllib.request.urlretrieve(url, dest)
+
+    def run_cmd(self, cmd, log_file, cwd=None):
+        print('Running', ' '.join(cmd))
+        with open(log_file, 'w') as f:
+            subprocess.run(cmd, cwd=cwd, stdout=f, stderr=subprocess.STDOUT, check=False)
+
+class PhpBench(Benchmark):
+    name = 'phpbench'
+    url = 'http://download.pureftpd.org/pub/phpbench/phpbench-0.8.1.tar.gz'
+    archive = os.path.join(CACHE, 'phpbench-0.8.1.tar.gz')
+    src_dir = os.path.join(CACHE, 'phpbench-0.8.1')
+
+    def install(self):
+        if not os.path.isdir(self.src_dir):
+            self.download(self.url, self.archive)
+            with tarfile.open(self.archive, 'r:gz') as t:
+                t.extractall(CACHE)
+
+    def run(self):
+        self.install()
+        log = os.path.join(RESULTS, 'phpbench.log')
+        self.run_cmd(['php', os.path.join(self.src_dir, 'phpbench.php')], log)
+        return self.parse(log)
+
+    def parse(self, log):
+        with open(log) as f:
+            for line in f:
+                m = re.search(r'Score\s*:\s*(\d+(?:\.\d+)?)', line)
+                if m:
+                    return float(m.group(1))
+        return None
+
+class SevenZip(Benchmark):
+    name = '7zip'
+
+    def run(self):
+        log = os.path.join(RESULTS, '7zip.log')
+        # Uses system 7z binary
+        cmd = ['7za', 'b'] if shutil.which('7za') else ['7z', 'b']
+        self.run_cmd(cmd, log)
+        return self.parse(log)
+
+    def parse(self, log):
+        rating = None
+        with open(log) as f:
+            for line in f:
+                if line.strip().startswith('Avr:'):
+                    parts = line.split()
+                    # compression rating field
+                    try:
+                        rating = float(parts[4])
+                    except (IndexError, ValueError):
+                        pass
+        return rating
+
+class OpenSSLBench(Benchmark):
+    name = 'openssl'
+
+    def run(self):
+        log = os.path.join(RESULTS, 'openssl.log')
+        self.run_cmd(['openssl', 'speed', 'rsa4096'], log)
+        return self.parse(log)
+
+    def parse(self, log):
+        with open(log) as f:
+            for line in f:
+                if '4096 bits' in line:
+                    parts = line.split()
+                    try:
+                        return float(parts[-2])
+                    except (IndexError, ValueError):
+                        pass
+        return None
+
+def main():
+    tests = {
+        'phpbench': PhpBench(),
+        '7zip': SevenZip(),
+        'openssl': OpenSSLBench(),
+    }
+
+    parser = argparse.ArgumentParser(description='Minimal PTS-like benchmark runner')
+    parser.add_argument('benchmarks', nargs='*', default=list(tests.keys()), help='Benchmarks to run')
+    args = parser.parse_args()
+
+    results = {}
+    for name in args.benchmarks:
+        if name not in tests:
+            print(f'Unknown benchmark: {name}')
+            continue
+        score = tests[name].run()
+        results[name] = score
+        print(f'{name}: {score}')
+
+    with open(os.path.join(RESULTS, 'summary.json'), 'w') as f:
+        json.dump(results, f, indent=2)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add new `pts_nix.py` tool implementing a tiny subset of the Phoronix Test Suite
- ignore generated `cache` and `results` folders
- document usage of the new script in `README.md`

## Testing
- `python3 -m py_compile pts_nix.py`
- `python pts_nix.py phpbench` *(fails: domain is not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_688bdfd45c5c832ca407b0ba18e3f616